### PR TITLE
New tweaks

### DIFF
--- a/lib/platforms/browser.js
+++ b/lib/platforms/browser.js
@@ -27,9 +27,7 @@ module.exports = function initBrowser(fluxApp, options) {
     var Component = route.handler;
 
     if (isInitialRender) {
-      var state = options.state ||
-        JSON.parse(document.getElementById(CONTAINER_ID)
-        .getAttribute('data-fluxapp-state'));
+      var state = options.state || window.fluxAppState;
 
       fluxApp.rehydrate(state);
 

--- a/lib/platforms/node.js
+++ b/lib/platforms/node.js
@@ -6,8 +6,8 @@ var _ = require('lodash');
 var utils = require('./utils');
 
 function genTemplate(containerId) {
-  return _.template("<div id='" + containerId + "' " +
-  "class='app' data-fluxapp-state='<%= state %>'><%= page %></div>");
+  return _.template("<div id='" + containerId + "' " +"class='app'><%= page %></div>" +
+    "<script type='text/javascript'>window.fluxAppState = <%= state %>;</script>");
 }
 
 var TEMPLATE = genTemplate(utils.CONTAINER_ID);

--- a/lib/store.js
+++ b/lib/store.js
@@ -11,7 +11,8 @@ var CHANGE_EVENT = 'changed';
  * Base Store
  */
 function BaseStore(spec) {
-  EventEmitter.apply(this);
+  EventEmitter.apply(this)
+  this.setMaxListeners(1000);
 
   this.state = this.getInitialState();
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.8",
-    "fluxapp-router": "^0.9.5",
+    "fluxapp-router": "^0.9.6",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
     "path-to-regexp": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxapp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A isomorphic flux app design implementation",
   "main": "lib/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.8",
-    "fluxapp-router": "^0.9.3",
+    "fluxapp-router": "^0.9.4",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
     "path-to-regexp": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.8",
-    "fluxapp-router": "^0.9.2",
+    "fluxapp-router": "^0.9.3",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
     "path-to-regexp": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxapp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A isomorphic flux app design implementation",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.8",
-    "fluxapp-router": "^0.9.4",
+    "fluxapp-router": "^0.9.5",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
     "path-to-regexp": "^1.0.1"


### PR DESCRIPTION
fixed (router & fluxApp):
- the current class sets on CS without warnings and updates as routes state changes
- the old fluxapp store is named routeOracle :dancer: 
- state is stored in a global variable provided by a script tag