### PR TITLE
Load without promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,11 @@ $(function() {
 
 #### Component load method
 
-If the component depends on data from any store, its `statics.load` method should return a promise
-that evaluates to an object that's going to be an initial state of application stores.
+If the component depends on data from any store, its `statics.load`
+should call actions that result in data populating appropriate stores. A
+promise need to be returned from `statics.load` if its concurrency is a
+result of something else than FluxApp actions. In such a case, the
+promise must be resolved once the data loading had finished.
 
 ```
 React.createClass({
@@ -227,14 +230,9 @@ React.createClass({
 
   statics : {
     load : function(request) {
-      var userData = fluxApp.getActions('user').getData();
-      var item = fluxApp.getActions('item').getDetails({
+      fluxApp.getActions('user').getData();
+      fluxApp.getActions('item').getDetails({
         itemId: request.params.itemId
-      });
-
-      return Promise.props({
-        user: userData,
-        item: item
       });
     }
   }

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -65,7 +65,6 @@ BaseActions.prototype._invokedActions = [];
 BaseActions.prototype._invokeAction = function _invokeAction(namespace, handler) {
   var args = Array.prototype.slice.call(arguments, 2);
   var response = Promise.method(handler).apply(this._fluxApp, args);
-  this._invokedActions.push(response);
 
   var pending = response.isPending();
   var actionDispatch = Promise.resolve();
@@ -86,7 +85,10 @@ BaseActions.prototype._invokeAction = function _invokeAction(namespace, handler)
     actionDispatch = this._dispatchAction(actionType, response.value());
   }
 
-  return Promise.join(response, actionDispatch)
+  var finishIndicator = Promise.join(response, actionDispatch)
+  this._invokedActions.push(finishIndicator);
+
+  return finishIndicator
   .spread(function formatResponse(result) {
     return [ actionType, result ];
   })

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -49,6 +49,8 @@ BaseActions.prototype._dispatchFailed = function _dispatchFailed(namespace, err)
   });
 };
 
+BaseActions.prototype._invokedActions = [];
+
 /**
  * Gets the action handler
  *
@@ -63,6 +65,8 @@ BaseActions.prototype._dispatchFailed = function _dispatchFailed(namespace, err)
 BaseActions.prototype._invokeAction = function _invokeAction(namespace, handler) {
   var args = Array.prototype.slice.call(arguments, 2);
   var response = Promise.method(handler).apply(this._fluxApp, args);
+  this._invokedActions.push(response);
+
   var pending = response.isPending();
   var actionDispatch = Promise.resolve();
   var actionType = namespaceTransform(namespace);

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
 var Dispatcher = require('./dispatcher');
 var Promise = require('bluebird');
 var router = require('fluxapp-router');
+var _ = require('lodash');
+var R = require('ramda');
 
 /**
  * Main module extry point
@@ -14,31 +16,86 @@ function FluxApp() {
   this._actions = {};
 }
 
+function scheduleLater() {
+  return new Promise(function(resolve) {
+    setTimeout(function resolver() {
+      resolve();
+    });
+  });
+}
+
+function pullStoreStates(self) {
+  return R.mapObj(R.prop('state'), R.pickBy(function (store) {
+    return !R.eqDeep(store.getInitialState(), store.state);
+  })(self._stores));
+}
+
+FluxApp.prototype._getInvokedActions = function _getInvokedActions(ctx) {
+  return _.flatten(_.map(ctx._actions, function(action) {
+    return action._invokedActions;
+  }));
+};
+
+FluxApp.prototype._getPopulatedStores = function _getPopulatedStores(ctx) {
+  ctx = ctx || this;
+  var self = this;
+
+  var invokedActions = this._getInvokedActions(ctx);
+
+  return Promise.all(invokedActions)
+  .then(scheduleLater)
+  .then(function checker() {
+    var allActions = self._getInvokedActions(ctx);
+
+    if (_.every(allActions, function (action) {
+      return ! action.isPending();
+    })) {
+      _.forEach(ctx._actions, function(action) {
+        action._invokedActions = [];
+      });
+
+      return pullStoreStates(ctx);
+    } else {
+      return self._getPopulatedStores(ctx);
+    }
+  });
+};
+
+FluxApp.prototype._handleRequest = function _handleRequest(Component, stores) {
+  var react = require('react');
+  var state = {
+    stores: stores || {}
+  };
+
+  // populate the stores with the data returned from the loader
+  this.rehydrate(state);
+
+  var page = react.renderToString(Component()); // jshint ignore:line
+
+  var payload = {
+    state: JSON.stringify(state),
+    page: page
+  };
+
+  return payload;
+};
+
 FluxApp.prototype.request = function request(route) {
   var react = require('react');
 
-  var self = this;
   var componentClass = route.handler;
   var Component = react.createFactory(componentClass);
   var context = this.createContext();
 
-  return componentClass.load(route, context).then(function handleRequest(stores) {
-    var state = {
-      stores: stores || {}
-    };
+  var handler = this._handleRequest.bind(this, Component);
+  var boundStoresGetter = this._getPopulatedStores.bind(this, context);
 
-    // populate the stores with the data returned from the loader
-    self.rehydrate(state);
-
-    var page = react.renderToString(Component()); // jshint ignore:line
-
-    var payload = {
-      state: JSON.stringify(state),
-      page: page
-    };
-
-    return payload;
-  });
+  var loadResult = componentClass.load(route, context);
+  if (typeof loadResult === 'object' && loadResult.then) {
+    return loadResult.then(boundStoresGetter).then(handler);
+  } else {
+    return boundStoresGetter().then(handler);
+  }
 };
 
 /**
@@ -159,7 +216,7 @@ FluxApp.prototype.getActions = function getActions(namespace) {
  */
 FluxApp.prototype.getAction = function getAction(namespace, method) {
   var actions = this._actions[ namespace ];
-  
+
   return actions[ method ].bind(actions);
 };
 

--- a/lib/platforms/browser.js
+++ b/lib/platforms/browser.js
@@ -33,9 +33,14 @@ module.exports = function initBrowser(fluxApp, options) {
 
       renderComponent(routeStore, Component, true, current.id);
     } else if (typeof Component.load === 'function') {
-      Component.load(route, fluxApp.createContext()).then(
-        renderComponent.bind(null, routeStore, Component, false, current.id)
-      );
+      var loadResult = Component.load(route, fluxApp.createContext());
+      var renderer = renderComponent.bind(null, routeStore, Component, false, current.id);
+
+      if (typeof loadResult === 'object' && loadResult.then) {
+        loadResult.then(renderer);
+      } else {
+        fluxApp._getPopulatedStores().then(renderer);
+      }
     } else {
       renderComponent(routeStore, Component, false, current.id);
     }

--- a/lib/store.js
+++ b/lib/store.js
@@ -208,10 +208,14 @@ BaseStore.prototype.dehydrate = function dehydrate() {
 BaseStore.prototype.rehydrate = function rehydrate(data) {
   this.state = this.getInitialState();
 
-  this._processActionEvent({
-    actionType : data[0],
-    payload : data[1]
-  });
+  if (data instanceof Array) {
+    this._processActionEvent({
+      actionType : data[0],
+      payload : data[1]
+    });
+  } else {
+    this.state = _.merge(this.state, data);
+  }
 
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "fluxapp-router": "^0.9.7",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
-    "path-to-regexp": "^1.0.1"
+    "path-to-regexp": "^1.0.1",
+    "ramda": "^0.10.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.8",
-    "fluxapp-router": "^0.9.6",
+    "fluxapp-router": "^0.9.7",
     "lodash": "^2.4.1",
     "path-match": "^1.2.2",
     "path-to-regexp": "^1.0.1"


### PR DESCRIPTION
A promise only needs to be returned from `statics.load` if load contains concurrency not resultant from actions.