### PR TITLE
Added clearer error response when fetching non-existance actions

### DIFF
--- a/lib/componentMixin.js
+++ b/lib/componentMixin.js
@@ -159,6 +159,10 @@ module.exports = {
   getAction : function getAction(namespace, method) {
     var actions = this.getActions(namespace);
 
+    if (! actions[method]) {
+      throw new Error('Method `' + method + '` not found in namespace `' + namespace + '`');
+    }
+
     return actions[method].bind(actions);
   },
 


### PR DESCRIPTION
Having everything in the framework/mixin makes it hard to find the problem
 without clearer errors