### PR TITLE
Async actions fire after event on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A pluggable isomorphic framework
 ## Resources
 
 * [Developer Portal](http://fluxapp.readme.io)
-* [Documentation](http://fluxapp.readme.io/v0.1.7/docs)
-* [Existing Plugins](http://fluxapp.readme.io/v0.1.7/docs/overview-6)
+* [Documentation](http://fluxapp.readme.io/v0.1.8/docs)
+* [Existing Plugins](http://fluxapp.readme.io/v0.1.8/docs/overview-6)
 
 ### Install
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -77,11 +77,10 @@ BaseActions.prototype._invokeAction = function _invokeAction(namespace, handler)
 
   if (pending) {
     actionDispatch = response.then(
-      this._dispatchAction.bind(this, actionType),
-      this._dispatchFailed.bind(this, namespace)
+      this._dispatchAction.bind(this, actionType)
     ).then(
       this._dispatchAfter.bind(this, namespace)
-    );
+    ).catch(this._dispatchFailed.bind(this, namespace));
   } else if (response.isRejected()) {
     this._dispatchFailed(namespace, response.reason());
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxapp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A isomorphic flux app design implementation",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Bring async actions in line with other types of actions, they should not fire the after event unless the action was successful.